### PR TITLE
Raise errors from unexpected Metrc API responses

### DIFF
--- a/Metrc.gemspec
+++ b/Metrc.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rake'
   spec.add_dependency 'rspec'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'webmock'
 end

--- a/lib/Metrc/client.rb
+++ b/lib/Metrc/client.rb
@@ -30,7 +30,7 @@ module Metrc
       options.merge!(basic_auth: auth_headers)
       puts "\nMetrc API Request debug\nclient.get('#{url}', #{options})\n########################\n" if debug
       self.response = self.class.get(url, options)
-      raise_response_errors
+      raise_request_errors
       if debug
         puts "\nMetrc API Response debug\n#{response.to_s[0..360]}\n[200 OK]\n########################\n"
         response
@@ -41,7 +41,7 @@ module Metrc
       options.merge!(basic_auth: auth_headers)
       puts "\nMetrc API Request debug\nclient.post('#{url}', #{options})\n########################\n" if debug
       self.response = self.class.post(url, options)
-      raise_response_errors
+      raise_request_errors
       if debug
         puts "\nMetrc API Response debug\n#{response.to_s[0..360]}\n[200 OK]\n########################\n"
         response
@@ -52,7 +52,7 @@ module Metrc
       options.merge!(basic_auth: auth_headers)
       puts "\nMetrc API Request debug\nclient.delete('#{url}', #{options})\n########################\n" if debug
       self.response = self.class.delete(url, options)
-      raise_response_errors
+      raise_request_errors
       if debug
         puts "\nMetrc API Response debug\n#{response.to_s[0..360]}\n[200 OK]\n########################\n"
         response
@@ -63,7 +63,7 @@ module Metrc
       options.merge!(basic_auth: auth_headers)
       puts "\nMetrc API Request debug\nclient.put('#{url}', #{options})\n########################\n" if debug
       self.response = self.class.put(url, options)
-      raise_response_errors
+      raise_request_errors
       if debug
         puts "\nMetrc API Response debug\n#{response.to_s[0..360]}\n[200 OK]\n########################\n"
         response
@@ -202,9 +202,9 @@ module Metrc
       Metrc.configuration
     end
 
-    def raise_response_errors
+    def raise_request_errors
       return if response.success?
-      raise Errors::BadRequest.new('An error has occurred while executing your request.') if response.bad_request?
+      raise Errors::BadRequest.new("An error has occurred while executing your request. #{Metrc::Errors.parse_request_errors(response: response)}") if response.bad_request?
       raise Errors::Unauthorized.new('Invalid or no authentication provided.') if response.unauthorized?
       raise Errors::Forbidden.new('The authenticated user does not have access to the requested resource.') if response.forbidden?
       raise Errors::NotFound.new('The requested resource could not be found (incorrect or invalid URI).') if response.not_found?

--- a/lib/Metrc/client.rb
+++ b/lib/Metrc/client.rb
@@ -30,6 +30,7 @@ module Metrc
       options.merge!(basic_auth: auth_headers)
       puts "\nMetrc API Request debug\nclient.get('#{url}', #{options})\n########################\n" if debug
       self.response = self.class.get(url, options)
+      raise_response_errors
       if debug
         puts "\nMetrc API Response debug\n#{response.to_s[0..360]}\n[200 OK]\n########################\n"
         response
@@ -40,6 +41,7 @@ module Metrc
       options.merge!(basic_auth: auth_headers)
       puts "\nMetrc API Request debug\nclient.post('#{url}', #{options})\n########################\n" if debug
       self.response = self.class.post(url, options)
+      raise_response_errors
       if debug
         puts "\nMetrc API Response debug\n#{response.to_s[0..360]}\n[200 OK]\n########################\n"
         response
@@ -50,6 +52,7 @@ module Metrc
       options.merge!(basic_auth: auth_headers)
       puts "\nMetrc API Request debug\nclient.delete('#{url}', #{options})\n########################\n" if debug
       self.response = self.class.delete(url, options)
+      raise_response_errors
       if debug
         puts "\nMetrc API Response debug\n#{response.to_s[0..360]}\n[200 OK]\n########################\n"
         response
@@ -60,6 +63,7 @@ module Metrc
       options.merge!(basic_auth: auth_headers)
       puts "\nMetrc API Request debug\nclient.put('#{url}', #{options})\n########################\n" if debug
       self.response = self.class.put(url, options)
+      raise_response_errors
       if debug
         puts "\nMetrc API Response debug\n#{response.to_s[0..360]}\n[200 OK]\n########################\n"
         response
@@ -196,6 +200,16 @@ module Metrc
 
     def configuration
       Metrc.configuration
+    end
+
+    def raise_response_errors
+      return if response.success?
+      raise Errors::BadRequest.new('An error has occurred while executing your request.') if response.bad_request?
+      raise Errors::Unauthorized.new('Invalid or no authentication provided.') if response.unauthorized?
+      raise Errors::Forbidden.new('The authenticated user does not have access to the requested resource.') if response.forbidden?
+      raise Errors::NotFound.new('The requested resource could not be found (incorrect or invalid URI).') if response.not_found?
+      raise Errors::TooManyRequests.new('The limit of API calls allowed has been exceeded. Please pace the usage rate of the API more apart.') if response.too_many_requests?
+      raise Errors::InternalServerError.new('An error has occurred while executing your request.') if response.server_error?
     end
   end
 end

--- a/lib/Metrc/errors.rb
+++ b/lib/Metrc/errors.rb
@@ -10,5 +10,32 @@ module Metrc
     class NotFound < RequestError; end
     class TooManyRequests < RequestError; end
     class InternalServerError < RequestError; end
+
+    class << self
+      def parse_request_errors(response:)
+        body = response.parsed_response
+        if body.is_a? Array
+          consolidate_errors_by_row(body).join(', ')
+        elsif body.is_a? Hash
+          body['Message']
+        end
+      end
+
+      private
+
+      def consolidate_errors_by_row(array)
+        array.reduce({}) do |errors, row|
+          index = row['row']
+          if errors[index]
+            errors[index] += ", #{row["message"]}"
+          else
+            errors[index] = row['message']
+          end
+          errors
+        end.map do |index, message|
+          "#{index}: #{message}"
+        end
+      end
+    end
   end
 end

--- a/lib/Metrc/errors.rb
+++ b/lib/Metrc/errors.rb
@@ -2,6 +2,13 @@ module Metrc
   module Errors
     class MissingConfiguration < RuntimeError; end
     class MissingParameter < RuntimeError; end
-    class NotFound < RuntimeError; end
+    class RequestError < RuntimeError; end
+
+    class BadRequest < RequestError; end
+    class Unauthorized < RequestError; end
+    class Forbidden < RequestError; end
+    class NotFound < RequestError; end
+    class TooManyRequests < RequestError; end
+    class InternalServerError < RequestError; end
   end
 end

--- a/spec/Metrc/client_spec.rb
+++ b/spec/Metrc/client_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe Metrc::Client do
+  before(:each) do
+    configure_client
+  end
+
+  let(:subject) { described_class.new(user_key: $spec_credentials['user_key']) }
+
+  describe '#api_post' do
+    let(:licenseNumber) { 'CML17-0000001' }
+    let(:api_url) { "/foo/v1/bar?licenseNumber=#{licenseNumber}" }
+    let(:api_post) { subject.api_post(api_url) }
+
+    before(:each) do
+      stub_request(:post, "#{$spec_credentials['base_uri']}#{api_url}")
+        .to_return(status: status)
+    end
+
+    context 'Metrc API returns 400' do
+      let(:status) { 400 }
+      it 'raises an error' do
+        expect { api_post }.to(raise_error(Metrc::Errors::BadRequest))
+      end
+    end
+
+    context 'Metrc API returns 401' do
+      let(:status) { 401 }
+      it 'raises an error' do
+        expect { api_post }.to(raise_error(Metrc::Errors::Unauthorized))
+      end
+    end
+
+    context 'Metrc API returns 403' do
+      let(:status) { 403 }
+      it 'raises an error' do
+        expect { api_post }.to(raise_error(Metrc::Errors::Forbidden))
+      end
+    end
+
+    context 'Metrc API returns 404' do
+      let(:status) { 404 }
+      it 'raises an error' do
+        expect { api_post }.to(raise_error(Metrc::Errors::NotFound))
+      end
+    end
+
+    context 'Metrc API returns 429' do
+      let(:status) { 429 }
+      it 'raises an error' do
+        expect { api_post }.to(raise_error(Metrc::Errors::TooManyRequests))
+      end
+    end
+
+    context 'Metrc API returns 500' do
+      let(:status) { 500 }
+      it 'raises an error' do
+        expect { api_post }.to(raise_error(Metrc::Errors::InternalServerError))
+      end
+    end
+  end
+end

--- a/spec/Metrc/client_spec.rb
+++ b/spec/Metrc/client_spec.rb
@@ -11,16 +11,27 @@ describe Metrc::Client do
     let(:licenseNumber) { 'CML17-0000001' }
     let(:api_url) { "/foo/v1/bar?licenseNumber=#{licenseNumber}" }
     let(:api_post) { subject.api_post(api_url) }
+    let(:body) { "" }
 
     before(:each) do
       stub_request(:post, "#{$spec_credentials['base_uri']}#{api_url}")
-        .to_return(status: status)
+        .to_return(status: status, body: body, headers: { 'content-type': 'application/json' })
     end
 
     context 'Metrc API returns 400' do
       let(:status) { 400 }
       it 'raises an error' do
         expect { api_post }.to(raise_error(Metrc::Errors::BadRequest))
+      end
+
+      context 'with a simple error' do
+        let(:body) do
+          { 'Message': 'No data was submitted.' }.to_json
+        end
+
+        it 'stores the error message' do
+          expect { api_post }.to(raise_error(/No data was submitted./))
+        end
       end
     end
 
@@ -57,6 +68,17 @@ describe Metrc::Client do
       it 'raises an error' do
         expect { api_post }.to(raise_error(Metrc::Errors::InternalServerError))
       end
+
+      # TODO: enhance error capturing for 500s once response format is known
+      #context 'with a simple error' do
+      #  let(:body) do
+      #    { 'Message': 'No data was submitted.' }.to_json
+      #  end
+
+      #  it 'stores the error message' do
+      #    expect { api_post }.to(raise_error('No data was submitted.'))
+      #  end
+      #end
     end
   end
 end

--- a/spec/Metrc/errors_spec.rb
+++ b/spec/Metrc/errors_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Metrc::Errors do
+  let(:subject) { described_class }
+
+  describe '.parse_request_errors' do
+    let(:body) { Hash.new }
+    let(:response) do
+      double(HTTParty::Response, parsed_response: body)
+    end
+    let(:parse_request_errors) { subject.parse_request_errors(response: response) }
+
+    context 'with a simple error' do
+      let(:body) do
+        { 'Message' => 'No data was submitted.' }
+      end
+
+      it 'stores the error message' do
+        expect(parse_request_errors).to match /No data was submitted./
+      end
+    end
+
+    context 'with multiple errors for the same row' do
+      let(:body) do
+        [
+          { 'row' => 0, 'message' => 'Room Id was not specified.' },
+          { 'row' => 0, 'message' => 'Room "My Room" already exists in the current Facility.' }
+        ]
+      end
+
+      it 'consolidates the error message from the api' do
+        expect(parse_request_errors).to match /Room Id was not specified/
+        expect(parse_request_errors).to match /Room "My Room" already exists in the current Facility/
+      end
+    end
+
+    context 'with errors for multilpe rows' do
+      let(:body) do
+        [
+          { 'row' => 0, 'message' => 'Room Id was not specified.' },
+          { 'row' => 1, 'message' => 'Room "My Room" already exists in the current Facility.' }
+        ]
+      end
+
+      it 'captures the error message for each row' do
+        expect(parse_request_errors).to match /0: Room Id was not specified/
+        expect(parse_request_errors).to match /1: Room "My Room" already exists in the current Facility/
+      end
+    end
+  end
+end

--- a/spec/Metrc_spec.rb
+++ b/spec/Metrc_spec.rb
@@ -39,16 +39,4 @@ describe Metrc do
   #
   # it 'communicates with the API to get inventory' do
   # end
-
-  private
-
-  def configure_client
-    Metrc.configure do |config|
-      config.api_key  = $spec_credentials['api_key']
-      config.user_key = $spec_credentials['user_key']
-      config.base_uri = $spec_credentials['base_uri']
-      config.state    = $spec_credentials['state']
-    end
-  end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,4 +3,11 @@ require 'yaml'
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 $spec_credentials = YAML.load_file('./spec/spec_CA_credentials.yml')
 
+require 'webmock/rspec'
 require 'Metrc'
+
+Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].each {|f| require f}
+
+RSpec.configure do |config|
+  config.include ConfigurationHelper
+end

--- a/spec/support/configuration_helper.rb
+++ b/spec/support/configuration_helper.rb
@@ -1,0 +1,10 @@
+module ConfigurationHelper
+  def configure_client
+    Metrc.configure do |config|
+      config.api_key  = $spec_credentials['api_key']
+      config.user_key = $spec_credentials['user_key']
+      config.base_uri = $spec_credentials['base_uri']
+      config.state    = $spec_credentials['state']
+    end
+  end
+end


### PR DESCRIPTION
creates a subclass of `Metrc::Errors` for request errors specific to responses from the Metrc API and raises them if we get a bad/unexpected response when making an API request. From the given documentation at https://api-ca.metrc.com/Documentation/#getting-started_server_responses only status codes 400 and 500 return error messages to parse, but there's no example for the 500 response body for me to be sure that I'm parsing the request correctly, so I only do so for 400s.

It would be ideal to have a full acceptance test that actually hits the API somewhere in this test suite so that if the API responses actually change then we know about it, but I don't want to include an Artemis-specific API/User key in the gem.