### PR TITLE
Use state and sandbox options to build the base URI

### DIFF
--- a/lib/Metrc/client.rb
+++ b/lib/Metrc/client.rb
@@ -8,13 +8,14 @@ module Metrc
 
     attr_accessor :debug,
                   :response,
-                  :user_key
-                  :parsed_response
+                  :user_key,
+                  :parsed_response,
+                  :uri
 
     def initialize(opts = {})
       self.debug = opts[:debug]
       self.user_key = opts[:user_key]
-      self.class.base_uri configuration.base_uri
+      self.class.base_uri build_uri
       sign_in
     end
 
@@ -200,6 +201,19 @@ module Metrc
 
     def configuration
       Metrc.configuration
+    end
+
+    def build_uri
+      return self.uri if self.uri
+      config   = configuration
+      self.uri = "api-#{config.state}.metrc.com"
+
+      if config.sandbox
+        self.uri.prepend('sandbox-')
+      end
+
+      self.uri.prepend('https://')
+      self.uri
     end
 
     def raise_request_errors

--- a/lib/Metrc/configuration.rb
+++ b/lib/Metrc/configuration.rb
@@ -2,13 +2,13 @@ module Metrc
   class Configuration
     attr_accessor :api_key,
                   :user_key,
-                  :base_uri,
                   :state,
                   :training,
-                  :results
+                  :results,
+                  :sandbox
 
     def incomplete?
-      [:api_key, :base_uri, :state].any? { |e| self.send(e).nil? }
+      [:api_key, :state].any? { |e| self.send(e).nil? }
     end
 
   end

--- a/lib/Metrc/version.rb
+++ b/lib/Metrc/version.rb
@@ -1,3 +1,3 @@
 module Metrc
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/Metrc/client_spec.rb
+++ b/spec/Metrc/client_spec.rb
@@ -14,7 +14,7 @@ describe Metrc::Client do
     let(:body) { "" }
 
     before(:each) do
-      stub_request(:post, "#{$spec_credentials['base_uri']}#{api_url}")
+      stub_request(:post, "#{subject.uri}#{api_url}")
         .to_return(status: status, body: body, headers: { 'content-type': 'application/json' })
     end
 

--- a/spec/Metrc_spec.rb
+++ b/spec/Metrc_spec.rb
@@ -9,7 +9,6 @@ describe Metrc do
 
   it 'accepts a configuration, requires a complete configuration' do
     Metrc.configure do |config|
-      config.base_uri = nil
       config.state  = nil
     end
 
@@ -20,7 +19,6 @@ describe Metrc do
 
   it 'does not initialize without credentials' do
     Metrc.configure do |config|
-      config.base_uri = nil
       config.state = nil
     end
 
@@ -28,10 +26,25 @@ describe Metrc do
       .to(raise_error(Metrc::Errors::MissingConfiguration))
   end
 
-  it 'initializes with credentials' do
+  it 'builds a sandbox base URI' do
+    Metrc.configure do |config|
+      config.sandbox = true
+      config.state   = :ca
+    end
 
-    expect { Metrc::Client.new }
-      .not_to raise_error
+    client = Metrc::Client.new
+
+    expect(client.uri).to eq('https://sandbox-api-ca.metrc.com')
+  end
+
+  it 'builds a production base URI' do
+    Metrc.configure do |config|
+      config.state = :ca
+    end
+
+    client = Metrc::Client.new
+
+    expect(client.uri).to eq('https://api-ca.metrc.com')
   end
 
   # it 'communicates with the API to get users' do

--- a/spec/spec_credentials.yml.sample
+++ b/spec/spec_credentials.yml.sample
@@ -1,4 +1,4 @@
 api_key: AAAAAAAAA
 user_key: BBBBBBBBB
-base_uri: https://sandbox-api.metrc.com
+sandbox: false
 state: ca

--- a/spec/support/configuration_helper.rb
+++ b/spec/support/configuration_helper.rb
@@ -3,7 +3,7 @@ module ConfigurationHelper
     Metrc.configure do |config|
       config.api_key  = $spec_credentials['api_key']
       config.user_key = $spec_credentials['user_key']
-      config.base_uri = $spec_credentials['base_uri']
+      config.sandbox  = $spec_credentials['sandbox']
       config.state    = $spec_credentials['state']
     end
   end


### PR DESCRIPTION
Because flexibility.