### PR TITLE
Remove depreciated "/plantbatches/v1/create/plantings?licenseNumber=" endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    Metrc (0.3.2)
+    Metrc (0.4.0)
       bundler
       httparty
       rake

--- a/lib/Metrc/client.rb
+++ b/lib/Metrc/client.rb
@@ -155,13 +155,7 @@ module Metrc
     end
 
     def create_plant_batch_package(license_number, resources)
-      return self.create_plant_batch_plantings(license_number, resources) if configuration.state.to_sym == :ca
-
       api_post("/plantbatches/v1/createpackages?licenseNumber=#{license_number}", body: resources.to_json)
-    end
-
-    def create_plant_batch_plantings(license_number, resources)
-      api_post("/plantbatches/v1/create/plantings?licenseNumber=#{license_number}", body: resources.to_json)
     end
 
     def create_plant_batch_package_from_mother(license_number, resources)
@@ -339,7 +333,7 @@ module Metrc
       self.uri
     end
 
-    def raise_request_errors # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def raise_request_errors # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
       return if response.success?
 
       raise Errors::BadRequest.new("An error has occurred while executing your request. #{Metrc::Errors.parse_request_errors(response: response)}") if response.bad_request?

--- a/lib/Metrc/client.rb
+++ b/lib/Metrc/client.rb
@@ -158,6 +158,10 @@ module Metrc
       api_post("/plantbatches/v1/createpackages?licenseNumber=#{license_number}", body: resources.to_json)
     end
 
+    def create_plant_batch_from_mother(license_number, resources)
+      api_post("/plants/v1/create/plantings?licenseNumber=#{license_number}", body: resources.to_json)
+    end
+
     def create_plant_batch_package_from_mother(license_number, resources)
       api_post("/plantbatches/v1/create/packages/frommotherplant?licenseNumber=#{license_number}", body: resources.to_json)
     end

--- a/lib/Metrc/client.rb
+++ b/lib/Metrc/client.rb
@@ -337,7 +337,7 @@ module Metrc
       self.uri
     end
 
-    def raise_request_errors # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+    def raise_request_errors # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       return if response.success?
 
       raise Errors::BadRequest.new("An error has occurred while executing your request. #{Metrc::Errors.parse_request_errors(response: response)}") if response.bad_request?

--- a/lib/Metrc/version.rb
+++ b/lib/Metrc/version.rb
@@ -1,3 +1,3 @@
 module Metrc
-  VERSION = '0.3.2'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/spec/Metrc/client_spec.rb
+++ b/spec/Metrc/client_spec.rb
@@ -99,6 +99,18 @@ describe Metrc::Client do
       end
     end
 
+    describe '#create_plant_batch_from_mother' do
+      before(:each) do
+        stub_request(:post, "#{subject.uri}/plants/v1/create/plantings?licenseNumber=#{licenseNumber}")
+          .with(headers: headers)
+          .to_return(body: nil)
+      end
+
+      it 'calls the endpoint' do
+        expect { subject.create_plant_batch_from_mother(licenseNumber, []) }.not_to raise_error
+      end
+    end
+
     describe '#split_plant_batch' do
       before do
         stub_request(:post, "#{subject.uri}/plantbatches/v1/split?licenseNumber=#{licenseNumber}")
@@ -120,7 +132,7 @@ describe Metrc::Client do
 
       context 'with a migrated state' do
         before do
-          stub_request(:post, "#{subject.uri}/plantbatches/v1/create/plantings?licenseNumber=#{licenseNumber}")
+          stub_request(:post, "#{subject.uri}/plantbatches/v1/createpackages?licenseNumber=#{licenseNumber}")
             .with(headers: headers)
             .to_return(body: nil)
         end

--- a/spec/Metrc/client_spec.rb
+++ b/spec/Metrc/client_spec.rb
@@ -99,18 +99,6 @@ describe Metrc::Client do
       end
     end
 
-    describe '#create_plant_batch_plantings' do
-      before do
-        stub_request(:post, "#{subject.uri}/plantbatches/v1/create/plantings?licenseNumber=#{licenseNumber}")
-          .with(headers: headers)
-          .to_return(body: nil)
-      end
-
-      it 'calls the endpoint' do
-        expect { subject.create_plant_batch_plantings(licenseNumber, []) }.not_to raise_error
-      end
-    end
-
     describe '#split_plant_batch' do
       before do
         stub_request(:post, "#{subject.uri}/plantbatches/v1/split?licenseNumber=#{licenseNumber}")


### PR DESCRIPTION
See Metrc API Bulletin Bulletin Number: 066

`"/plantbatches/v1/create/plantings?licenseNumber=` has been depriciated in favor of
`"/plants/v1/create/plantings?licenseNumber=`

